### PR TITLE
i18n error messages, i18n config, and updated lang set command

### DIFF
--- a/fcli-common/src/main/java/com/fortify/cli/common/locale/LanguageHelper.java
+++ b/fcli-common/src/main/java/com/fortify/cli/common/locale/LanguageHelper.java
@@ -17,7 +17,7 @@ public class LanguageHelper implements IFortifyCLIInitializer {
         this.config = config;
     }
 
-    private boolean isNullEmptyOrEn(String lang){
+    public boolean isNullEmptyOrEn(String lang){
         boolean t = false;
         if(lang == null || lang.isEmpty() || lang.toLowerCase() == "en"){
             t = true;
@@ -25,7 +25,7 @@ public class LanguageHelper implements IFortifyCLIInitializer {
         return t;
     }
 
-    private boolean isNullEmptyOrEn(){
+    public boolean isNullEmptyOrEn(){
         return isNullEmptyOrEn(config.get(CONFIG_KEY));
     }
 

--- a/fcli-config/src/main/java/com/fortify/cli/config/picocli/command/language/LanguageSetCommand.java
+++ b/fcli-config/src/main/java/com/fortify/cli/config/picocli/command/language/LanguageSetCommand.java
@@ -14,9 +14,8 @@ public class LanguageSetCommand extends AbstractLanguageCommand {
     @CommandLine.Mixin
     private OutputMixin outputMixin;
 
-    @CommandLine.Option(
-            names = {"-l", "--lang"}
-    )
+    // TODO: Need to internationalize paramLabel at some point.
+    @CommandLine.Parameters(index = "0", descriptionKey = "fcli.config.language.set.language")
     private String language;
 
     @PostConstruct

--- a/fcli-config/src/main/resources/com/fortify/cli/config/i18n/ConfigMessages.properties
+++ b/fcli-config/src/main/resources/com/fortify/cli/config/i18n/ConfigMessages.properties
@@ -11,4 +11,5 @@ fcli.config.generate-completion.usage.description = Generate bash/zsh completion
 fcli.config.language.usage.description = Commands for listing and setting languages that FCLI's help information can be outputted in.
 fcli.config.language.list.usage.description = List all supported languages.
 fcli.config.language.set.usage.description = Set a default language.
+fcli.config.language.set.language = The 2 letter code for the language you want FCLI to output information in. For a list of supported languages, please use the `${ROOT-COMMAND-NAME:-$PARENTCOMMAND} config language list` command.
 fcli.config.language.get.usage.description = Get the currently set language/locale.

--- a/fcli-config/src/main/resources/com/fortify/cli/config/i18n/ConfigMessages_nl.properties
+++ b/fcli-config/src/main/resources/com/fortify/cli/config/i18n/ConfigMessages_nl.properties
@@ -11,4 +11,5 @@ fcli.config.generate-completion.usage.description = Genereer bash/zsh voltooiing
 fcli.config.language.usage.description = Commando's voor het weergeven en instellen van talen waarin de helpinformatie van FCLI kan worden uitgevoerd.
 fcli.config.language.list.usage.description = Lijst van alle ondersteunde talen.
 fcli.config.language.set.usage.description = Stel een standaardtaal in.
+fcli.config.language.set.language = De 2-lettercode voor de taal waarin u FCLI informatie wilt laten weergeven. Voor een lijst met ondersteunde talen, gebruik de configuratietaal `${ROOT-COMMAND-NAME:-$PARENTCOMMAND} list` commando.
 fcli.config.language.get.usage.description = De momenteel ingestelde taal/landinstelling ophalen.

--- a/src/main/java/com/fortify/cli/app/FortifyCLI.java
+++ b/src/main/java/com/fortify/cli/app/FortifyCLI.java
@@ -24,16 +24,16 @@
  ******************************************************************************/
 package com.fortify.cli.app;
 
+import com.fortify.cli.app.exception.I18nParameterExceptionHandler;
+import com.fortify.cli.common.locale.LanguageHelper;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.impl.LogFactoryImpl;
 import org.apache.commons.logging.impl.SimpleLog;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 import org.jasypt.normalization.Normalizer;
-
 import com.fortify.cli.common.config.IFortifyCLIInitializer;
 import com.oracle.svm.core.annotate.AutomaticFeature;
-
 import io.micronaut.configuration.picocli.MicronautFactory;
 import io.micronaut.configuration.picocli.PicocliRunner;
 import io.micronaut.context.ApplicationContext;
@@ -70,7 +70,13 @@ public class FortifyCLI {
 		try (ApplicationContext applicationContext = ApplicationContext.builder(FortifyCLI.class, Environment.CLI).start()) {
 			try ( MicronautFactory micronautFactory = new MicronautFactory(applicationContext) ) {
 				applicationContext.getBeansOfType(IFortifyCLIInitializer.class).forEach(b -> b.initializeFortifyCLI(args));
-				return new CommandLine(FCLIRootCommands.class, micronautFactory).execute(args);
+				CommandLine commandLine = new CommandLine(FCLIRootCommands.class, micronautFactory);
+				return commandLine.setParameterExceptionHandler(
+						new I18nParameterExceptionHandler(
+								commandLine.getParameterExceptionHandler(),
+								applicationContext.getBean(LanguageHelper.class)
+						)
+				).execute(args);
 			}
 		}
 	}

--- a/src/main/java/com/fortify/cli/app/exception/I18nParameterExceptionHandler.java
+++ b/src/main/java/com/fortify/cli/app/exception/I18nParameterExceptionHandler.java
@@ -1,0 +1,62 @@
+package com.fortify.cli.app.exception;
+
+import com.fortify.cli.common.locale.LanguageHelper;
+import picocli.CommandLine;
+import picocli.CommandLine.ParameterException;
+import picocli.CommandLine.IParameterExceptionHandler;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+public class I18nParameterExceptionHandler implements CommandLine.IParameterExceptionHandler {
+    private final IParameterExceptionHandler origDefaultHandler;
+    private final ResourceBundle i18nResource;
+
+
+    /**
+     * This constructor will setup the custom Picocli Parameter Exception Handler so that error messages can be
+     * localized. The constructor needs the original default exception handler from Picocli so that if there's an error
+     * that does not have a localized version of the error message, then the original error message in English can still
+     * be displayed. Finally, access to {@link LanguageHelper} will provide access to the appropriate resource file.
+     * @param origDefaultHandler
+     * @param languageHelper
+     */
+    public I18nParameterExceptionHandler(IParameterExceptionHandler origDefaultHandler, LanguageHelper languageHelper){
+        this.origDefaultHandler = origDefaultHandler;
+        String resourceBundleName = "com.fortify.cli.i18n.FortifyCLIMessages";
+        i18nResource = ResourceBundle.getBundle(resourceBundleName,
+                new Locale(
+                        languageHelper.isNullEmptyOrEn() ? "" : languageHelper.getLanguageConfig()
+                )
+        );
+    }
+
+    /**
+     * A custom handler to allow for internationalization of important error messages.
+     * Handles a {@code ParameterException} that occurred and returns an exit code.
+     *
+     * @param ex   the ParameterException describing the problem that occurred while parsing the command line arguments,
+     *             and the CommandLine representing the command or subcommand whose input was invalid
+     * @param args the command line arguments that could not be parsed
+     * @return an exit code
+     */
+    @Override
+    public int handleParseException(ParameterException ex, String[] args) throws Exception {
+        // TODO: Add additional cases so that all standard error messages can be handled.
+        if (ex != null && ex.getMessage().contains("Missing required subcommand")){
+            String msg = i18nResource.getString("error.missing.subcommand");
+            CommandLine cmd = ex.getCommandLine();
+            cmd.getErr().println(msg);
+            cmd.usage(cmd.getErr());
+            return cmd.getCommandSpec().exitCodeOnInvalidInput();
+        } else if(ex != null && ex.getMessage().contains("Missing required parameter:")){
+            String msg = i18nResource.getString("error.missing.parameter");
+            CommandLine cmd = ex.getCommandLine();
+            cmd.getErr().println(msg + ex.getMessage().split(":")[1]);
+            cmd.usage(cmd.getErr());
+            return cmd.getCommandSpec().exitCodeOnInvalidInput();
+        }
+        // returns the original default handler and print things normally
+        return origDefaultHandler.handleParseException(ex, args);
+    }
+}

--- a/src/main/resources/com/fortify/cli/i18n/FortifyCLIMessages.properties
+++ b/src/main/resources/com/fortify/cli/i18n/FortifyCLIMessages.properties
@@ -1,3 +1,10 @@
+# Error messages:
+error.missing.subcommand = Missing required subcommand
+error.missing.parameter = Missing required parameter:
+error.missing.option = Missing required option
+error.unmatched.argument = Unmatched argument at index
+error.unmatched.command = Did you mean
+
 # Generic help text elements
 usage.footer = %n(c) Copyright 2021 Micro Focus
 usage.optionListHeading = %nGeneric options:%n
@@ -16,7 +23,7 @@ fields = Define the fields to be included in the output, together with optional 
 flatten = For non-column-based outputs, whether to flatten the structure
 no-headers = For column-based outputs, whether to output headers
 json-path = Transforms output using JSONPath
-output = Output file 
+output = Output file
 
 # Help text elements for FCLIRootCommands
 fcli.usage.description = Command-line interface for working with various Fortify products

--- a/src/main/resources/com/fortify/cli/i18n/FortifyCLIMessages_nl.properties
+++ b/src/main/resources/com/fortify/cli/i18n/FortifyCLIMessages_nl.properties
@@ -1,0 +1,29 @@
+# Foutmeldingen:
+error.missing.subcommand = Ontbrekende vereiste subopdracht
+error.missing.parameter = Ontbrekende vereiste parameter:
+error.missing.option = Ontbrekende vereiste optie
+error.unmatched.argument = Niet-overeenkomend argument bij index
+error.unmatched.command = Bedoelde je
+
+# Algemene helptekstelementen
+usage.footer = %n(c) Copyright 2021 Micro Focus
+usage.optionListHeading = %nAlgemene opties:%n
+
+# Algemene optiebeschrijvingen
+help = Toon dit helpbericht en sluit af
+version = Print versie-informatie en sluit af
+
+# Beschrijvingen voor logboekopties zoals gedefinieerd in de klasse LoggingMixin
+log-level = Stel logniveau in. Houd er rekening mee dat DEBUG- en TRACE-niveaus ertoe kunnen leiden dat gevoelige gegevens naar het logbestand worden geschreven. Toegestane waarden: ${COMPLETION-CANDIDATES}
+log-file = Bestand waar loggegevens worden weggeschreven. Indien niet gespecificeerd, worden er geen loggegevens geschreven.
+
+# Beschrijvingen voor logboekopties zoals gedefinieerd in de klasse OutputMixin
+format = Uitvoerformaat. Mogelijke waarden: ${COMPLETION-CANDIDATES}.
+fields = Definieer de velden die in de uitvoer moeten worden opgenomen, samen met optionele kopnamen
+flatten = Voor niet-kolomgebaseerde outputs, of de structuur moet worden afgevlakt
+no-headers = Voor op kolommen gebaseerde uitvoer, of kopteksten moeten worden uitgevoerd
+json-path = Transformeert uitvoer met JSONPath
+output = Uitvoerbestand
+
+# Help-tekstelementen voor FCLIrootCommands
+fcli.usage.description = Opdrachtregelinterface voor het werken met verschillende Fortify-producten


### PR DESCRIPTION
This PR has the the following major updates:

- allow for saving preferred default language
- custom picocli error handler for localizing picocli error messages
- updating to `lang set` command accept the preferred language as a positional argument rather than requiring the "-l" parameter