### PR TITLE
SSC roles

### DIFF
--- a/fcli-common/src/main/java/com/fortify/cli/common/output/writer/table/TableRecordWriter.java
+++ b/fcli-common/src/main/java/com/fortify/cli/common/output/writer/table/TableRecordWriter.java
@@ -81,8 +81,14 @@ public class TableRecordWriter implements IRecordWriter {
         }
         return columns;
     }
-    
+
+    // TODO: Some REST APIs will return a varying set of properties for individual records. We should review null processing here.
     private String[] getRow(ObjectNode record, String[] columns) {
+        for(String propertyName : columns){
+            if (record.get(propertyName) == null) {
+                record.put(propertyName, "null");
+            }
+        }
         return Stream.of(columns).map(record::get).map(JsonNode::asText).map(v->"null".equals(v)?"N/A":v).toArray(String[]::new);
     }
 

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/_main/cli/cmd/SSCCommands.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/_main/cli/cmd/SSCCommands.java
@@ -18,6 +18,8 @@ import com.fortify.cli.ssc.job.cli.cmd.SSCJobCommands;
 import com.fortify.cli.ssc.plugin.cli.cmd.SSCPluginCommands;
 import com.fortify.cli.ssc.report_template.cli.cmd.SSCReportTemplateCommands;
 import com.fortify.cli.ssc.rest.cli.cmd.SSCRestCommand;
+import com.fortify.cli.ssc.role.cli.cmd.SSCRoleCommands;
+import com.fortify.cli.ssc.role_permission.cli.cmd.SSCRolePermissionCommands;
 import com.fortify.cli.ssc.seed_bundle.cli.cmd.SSCSeedBundleCommands;
 import com.fortify.cli.ssc.session.cli.cmd.SSCSessionCommands;
 import com.fortify.cli.ssc.token.cli.cmd.SSCTokenCommands;
@@ -48,6 +50,8 @@ import picocli.CommandLine.Command;
                 SSCJobCommands.class,
                 SSCPluginCommands.class,
                 SSCReportTemplateCommands.class,
+                SSCRoleCommands.class,
+                SSCRolePermissionCommands.class,
                 SSCSeedBundleCommands.class,
                 SSCTokenCommands.class,
                 SSCTokenDefinitionCommands.class

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCommands.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCommands.java
@@ -6,10 +6,10 @@ import picocli.CommandLine.Command;
         name = "role",
         aliases = {},
         subcommands = {
-                SSCRoleListCommand.class,
-                SSCRoleGetCommand.class,
                 SSCRoleCreateCommand.class,
-                SSCRoleDeleteCommand.class
+                SSCRoleDeleteCommand.class,
+                SSCRoleGetCommand.class,
+                SSCRoleListCommand.class
         }
 
 )

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCommands.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCommands.java
@@ -7,7 +7,9 @@ import picocli.CommandLine.Command;
         aliases = {},
         subcommands = {
                 SSCRoleListCommand.class,
-                SSCRoleGetCommand.class
+                SSCRoleGetCommand.class,
+                SSCRoleCreateCommand.class,
+                SSCRoleDeleteCommand.class
         }
 
 )

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCommands.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCommands.java
@@ -6,7 +6,8 @@ import picocli.CommandLine.Command;
         name = "role",
         aliases = {},
         subcommands = {
-                SSCRoleListCommand.class
+                SSCRoleListCommand.class,
+                SSCRoleGetCommand.class
         }
 
 )

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCommands.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCommands.java
@@ -1,0 +1,14 @@
+package com.fortify.cli.ssc.role.cli.cmd;
+
+import picocli.CommandLine.Command;
+
+@Command(
+        name = "role",
+        aliases = {},
+        subcommands = {
+                SSCRoleListCommand.class
+        }
+
+)
+public class SSCRoleCommands {
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCreateCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCreateCommand.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.output.cli.mixin.IOutputConfigSupplier;
 import com.fortify.cli.common.output.cli.mixin.OutputConfig;
 import com.fortify.cli.common.output.cli.mixin.OutputMixin;
@@ -80,10 +81,7 @@ public class SSCRoleCreateCommand extends AbstractSSCUnirestRunnerCommand implem
         newRole.put("name",name);
         newRole.put("description", description);
         newRole.put("allApplicationRole", allApplicationRole);
-
-        ArrayNode permissionsNode = (new ObjectMapper()).createArrayNode();
-        Arrays.stream(permissionIds).forEach(permissionsNode::add);
-        newRole.set("permissionIds", permissionsNode);
+        newRole.set("permissionIds", JsonHelper.toArrayNode(permissionIds));
 
         outputMixin.write(
                 unirest.post(SSCUrls.ROLES).body(newRole)

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCreateCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCreateCommand.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * (c) Copyright 2021 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the 
+ * "Software"), to deal in the Software without restriction, including without 
+ * limitation the rights to use, copy, modify, merge, publish, distribute, 
+ * sublicense, and/or sell copies of the Software, and to permit persons to 
+ * whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY 
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.fortify.cli.ssc.role.cli.cmd;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.output.cli.mixin.IOutputConfigSupplier;
+import com.fortify.cli.common.output.cli.mixin.OutputConfig;
+import com.fortify.cli.common.output.cli.mixin.OutputMixin;
+import com.fortify.cli.ssc.rest.SSCUrls;
+import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCUnirestRunnerCommand;
+import com.fortify.cli.ssc.role.cli.mixin.SSCRoleResolverMixin;
+import com.fortify.cli.ssc.util.SSCOutputConfigHelper;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import kong.unirest.JsonNode;
+import kong.unirest.UnirestInstance;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import java.util.Arrays;
+
+@ReflectiveAccess
+@Command(name = "create")
+public class SSCRoleCreateCommand extends AbstractSSCUnirestRunnerCommand implements IOutputConfigSupplier {
+
+    @Mixin
+    private OutputMixin outputMixin;
+
+/*
+    # NOTE: There are some permissions that have a dependency on another permission.
+    When using the REST API, SSC will not tell you if you have unsatisfied permission dependencies.
+ */
+
+    @Getter
+    @Option(names = {"-n", "--name"}, required = true)
+    private String name;
+
+    @Getter
+    @Option(names = {"-d", "--description"})
+    private String description;
+
+    @Getter
+    @Option(names = "--universal-access", defaultValue = "false")
+    private Boolean allApplicationRole;
+
+    @Getter
+    @Option(names = {"-p", "--permission-id"})
+    private String[] permissionIds;
+
+    @SneakyThrows
+    protected Void run(UnirestInstance unirest) {
+        ObjectNode newRole = (new ObjectMapper()).createObjectNode();
+        newRole.put("name",name);
+        newRole.put("description", description);
+        newRole.put("allApplicationRole", allApplicationRole);
+
+        ArrayNode permissionsNode = (new ObjectMapper()).createArrayNode();
+        Arrays.stream(permissionIds).forEach(permissionsNode::add);
+        newRole.set("permissionIds", permissionsNode);
+
+        outputMixin.write(
+                unirest.post(SSCUrls.ROLES).body(newRole)
+        );
+        return null;
+    }
+
+    @Override
+    public OutputConfig getOutputOptionsWriterConfig() {
+        return SSCOutputConfigHelper.tableFromData()
+                .defaultColumns("id#name#permissionIds");
+    }
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCreateCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleCreateCommand.java
@@ -25,8 +25,6 @@
 package com.fortify.cli.ssc.role.cli.cmd;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.json.JsonHelper;
 import com.fortify.cli.common.output.cli.mixin.IOutputConfigSupplier;
@@ -34,18 +32,15 @@ import com.fortify.cli.common.output.cli.mixin.OutputConfig;
 import com.fortify.cli.common.output.cli.mixin.OutputMixin;
 import com.fortify.cli.ssc.rest.SSCUrls;
 import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCUnirestRunnerCommand;
-import com.fortify.cli.ssc.role.cli.mixin.SSCRoleResolverMixin;
 import com.fortify.cli.ssc.util.SSCOutputConfigHelper;
 import io.micronaut.core.annotation.ReflectiveAccess;
-import kong.unirest.JsonNode;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
-
-import java.util.Arrays;
+import picocli.CommandLine.Parameters;
 
 @ReflectiveAccess
 @Command(name = "create")
@@ -60,7 +55,7 @@ public class SSCRoleCreateCommand extends AbstractSSCUnirestRunnerCommand implem
  */
 
     @Getter
-    @Option(names = {"-n", "--name"}, required = true)
+    @Parameters(index = "0", paramLabel = "role-name")
     private String name;
 
     @Getter
@@ -91,7 +86,7 @@ public class SSCRoleCreateCommand extends AbstractSSCUnirestRunnerCommand implem
 
     @Override
     public OutputConfig getOutputOptionsWriterConfig() {
-        return SSCOutputConfigHelper.tableFromData()
+        return SSCOutputConfigHelper.table()
                 .defaultColumns("id#name#permissionIds");
     }
 }

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleDeleteCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleDeleteCommand.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * (c) Copyright 2021 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the 
+ * "Software"), to deal in the Software without restriction, including without 
+ * limitation the rights to use, copy, modify, merge, publish, distribute, 
+ * sublicense, and/or sell copies of the Software, and to permit persons to 
+ * whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY 
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.fortify.cli.ssc.role.cli.cmd;
+
+import com.fortify.cli.common.output.cli.mixin.IOutputConfigSupplier;
+import com.fortify.cli.common.output.cli.mixin.OutputConfig;
+import com.fortify.cli.common.output.cli.mixin.OutputMixin;
+import com.fortify.cli.ssc.rest.SSCUrls;
+import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCUnirestRunnerCommand;
+import com.fortify.cli.ssc.role.cli.mixin.SSCRoleResolverMixin;
+import com.fortify.cli.ssc.util.SSCOutputConfigHelper;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import kong.unirest.UnirestInstance;
+import lombok.SneakyThrows;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Mixin;
+
+@ReflectiveAccess
+@Command(name = "delete")
+public class SSCRoleDeleteCommand extends AbstractSSCUnirestRunnerCommand implements IOutputConfigSupplier {
+    @Mixin
+    private SSCRoleResolverMixin.PositionalParameter role;
+
+    @Mixin
+    private OutputMixin outputMixin;
+
+    @SneakyThrows
+    protected Void run(UnirestInstance unirest) {
+        outputMixin.write(
+                unirest.delete(SSCUrls.ROLE(role.getRoleId(unirest)))
+        );
+        return null;
+    }
+
+    @Override
+    public OutputConfig getOutputOptionsWriterConfig() {
+        return SSCOutputConfigHelper.tableFromData()
+                .defaultColumns("message#errorCode#responseCode");
+    }
+
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleDeleteCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleDeleteCommand.java
@@ -41,7 +41,7 @@ import picocli.CommandLine.Mixin;
 @Command(name = "delete")
 public class SSCRoleDeleteCommand extends AbstractSSCUnirestRunnerCommand implements IOutputConfigSupplier {
     @Mixin
-    private SSCRoleResolverMixin.PositionalParameter role;
+    private SSCRoleResolverMixin.PositionalParameter roleResolver;
 
     @Mixin
     private OutputMixin outputMixin;
@@ -49,14 +49,14 @@ public class SSCRoleDeleteCommand extends AbstractSSCUnirestRunnerCommand implem
     @SneakyThrows
     protected Void run(UnirestInstance unirest) {
         outputMixin.write(
-                unirest.delete(SSCUrls.ROLE(role.getRoleId(unirest)))
+                unirest.delete(SSCUrls.ROLE(roleResolver.getRoleId(unirest)))
         );
         return null;
     }
 
     @Override
     public OutputConfig getOutputOptionsWriterConfig() {
-        return SSCOutputConfigHelper.tableFromData()
+        return SSCOutputConfigHelper.table()
                 .defaultColumns("message#errorCode#responseCode");
     }
 

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleGetCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleGetCommand.java
@@ -42,7 +42,4 @@ public class SSCRoleGetCommand extends AbstractSSCGetCommand {
     protected JsonNode generateOutput(UnirestInstance unirest) {
         return roleResolver.getRole(unirest).asJsonNode();
     }
-
-    @Override
-    protected boolean isOutputWrappedInDataObject() { return false; }
 }

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleGetCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleGetCommand.java
@@ -24,11 +24,11 @@
  ******************************************************************************/
 package com.fortify.cli.ssc.role.cli.cmd;
 
-import com.fortify.cli.common.output.cli.mixin.OutputConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.ssc.rest.SSCUrls;
-import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCTableOutputCommand;
+import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCGetCommand;
 import com.fortify.cli.ssc.role.cli.mixin.SSCRoleResolverMixin;
-import com.fortify.cli.ssc.util.SSCOutputHelper;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import kong.unirest.GetRequest;
 import kong.unirest.UnirestInstance;
@@ -37,7 +37,7 @@ import picocli.CommandLine.Command;
 
 @ReflectiveAccess
 @Command(name = "get")
-public class SSCRoleGetCommand extends AbstractSSCTableOutputCommand {
+public class SSCRoleGetCommand extends AbstractSSCGetCommand {
     @Mixin
     private SSCRoleResolverMixin.PositionalParameter role;
 
@@ -46,8 +46,11 @@ public class SSCRoleGetCommand extends AbstractSSCTableOutputCommand {
     }
 
     @Override
-    public OutputConfig getOutputOptionsWriterConfig() {
-        return SSCOutputHelper.defaultTableOutputConfig()
-                .defaultColumns("id#name#permissionIds");
+    protected JsonNode generateOutput(UnirestInstance unirest) {
+        return unirest.get(SSCUrls.ROLE(role.getRoleId(unirest)))
+                .asObject(ObjectNode.class).getBody();
     }
+
+    @Override
+    protected boolean isOutputWrappedInDataObject() { return true; }
 }

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleGetCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleGetCommand.java
@@ -25,12 +25,9 @@
 package com.fortify.cli.ssc.role.cli.cmd;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fortify.cli.ssc.rest.SSCUrls;
 import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCGetCommand;
 import com.fortify.cli.ssc.role.cli.mixin.SSCRoleResolverMixin;
 import io.micronaut.core.annotation.ReflectiveAccess;
-import kong.unirest.GetRequest;
 import kong.unirest.UnirestInstance;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Command;
@@ -39,18 +36,13 @@ import picocli.CommandLine.Command;
 @Command(name = "get")
 public class SSCRoleGetCommand extends AbstractSSCGetCommand {
     @Mixin
-    private SSCRoleResolverMixin.PositionalParameter role;
-
-    protected GetRequest generateRequest(UnirestInstance unirest) {
-        return unirest.get(SSCUrls.ROLE(role.getRoleId(unirest)));
-    }
+    private SSCRoleResolverMixin.PositionalParameter roleResolver;
 
     @Override
     protected JsonNode generateOutput(UnirestInstance unirest) {
-        return unirest.get(SSCUrls.ROLE(role.getRoleId(unirest)))
-                .asObject(ObjectNode.class).getBody();
+        return roleResolver.getRole(unirest).asJsonNode();
     }
 
     @Override
-    protected boolean isOutputWrappedInDataObject() { return true; }
+    protected boolean isOutputWrappedInDataObject() { return false; }
 }

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleGetCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleGetCommand.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * (c) Copyright 2021 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the 
+ * "Software"), to deal in the Software without restriction, including without 
+ * limitation the rights to use, copy, modify, merge, publish, distribute, 
+ * sublicense, and/or sell copies of the Software, and to permit persons to 
+ * whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY 
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.fortify.cli.ssc.role.cli.cmd;
+
+import com.fortify.cli.common.output.cli.mixin.OutputConfig;
+import com.fortify.cli.ssc.rest.SSCUrls;
+import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCTableOutputCommand;
+import com.fortify.cli.ssc.role.cli.mixin.SSCRoleResolverMixin;
+import com.fortify.cli.ssc.util.SSCOutputHelper;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import kong.unirest.GetRequest;
+import kong.unirest.UnirestInstance;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Command;
+
+@ReflectiveAccess
+@Command(name = "get")
+public class SSCRoleGetCommand extends AbstractSSCTableOutputCommand {
+    @Mixin
+    private SSCRoleResolverMixin.PositionalParameter role;
+
+    protected GetRequest generateRequest(UnirestInstance unirest) {
+        return unirest.get(SSCUrls.ROLE(role.getRoleId(unirest)));
+    }
+
+    @Override
+    public OutputConfig getOutputOptionsWriterConfig() {
+        return SSCOutputHelper.defaultTableOutputConfig()
+                .defaultColumns("id#name#permissionIds");
+    }
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleListCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleListCommand.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * (c) Copyright 2021 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the 
+ * "Software"), to deal in the Software without restriction, including without 
+ * limitation the rights to use, copy, modify, merge, publish, distribute, 
+ * sublicense, and/or sell copies of the Software, and to permit persons to 
+ * whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included 
+ * in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY 
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.fortify.cli.ssc.role.cli.cmd;
+
+import com.fortify.cli.common.output.cli.mixin.filter.AddAsDefaultColumn;
+import com.fortify.cli.common.output.cli.mixin.filter.OutputFilter;
+import com.fortify.cli.ssc.rest.SSCUrls;
+import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCTableOutputCommand;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import kong.unirest.GetRequest;
+import kong.unirest.UnirestInstance;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@ReflectiveAccess
+@Command(name = "list")
+public class SSCRoleListCommand extends AbstractSSCTableOutputCommand {
+    @Option(names={"--id"}) @OutputFilter @AddAsDefaultColumn
+    private String id;
+
+    @Option(names={"--name"}) @OutputFilter @AddAsDefaultColumn
+    private String name;
+
+    protected GetRequest generateRequest(UnirestInstance unirest) {
+        return unirest.get(SSCUrls.ROLES).queryString("limit", "-1");
+    }
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleListCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleListCommand.java
@@ -28,6 +28,7 @@ import com.fortify.cli.common.output.cli.mixin.filter.AddAsDefaultColumn;
 import com.fortify.cli.common.output.cli.mixin.filter.OutputFilter;
 import com.fortify.cli.ssc.rest.SSCUrls;
 import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCTableOutputCommand;
+import com.fortify.cli.ssc.rest.cli.mixin.filter.SSCFilterQParam;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import kong.unirest.GetRequest;
 import kong.unirest.UnirestInstance;
@@ -37,13 +38,25 @@ import picocli.CommandLine.Option;
 @ReflectiveAccess
 @Command(name = "list")
 public class SSCRoleListCommand extends AbstractSSCTableOutputCommand {
-    @Option(names={"--id"}) @OutputFilter @AddAsDefaultColumn
+
+    @Option(names={"--id"}) @SSCFilterQParam @AddAsDefaultColumn
     private String id;
 
-    @Option(names={"--name"}) @OutputFilter @AddAsDefaultColumn
+    @Option(names={"--name"}) @SSCFilterQParam @AddAsDefaultColumn
     private String name;
 
+    @Option(names={"--builtIn"}) @OutputFilter
+    private Boolean builtIn;
+
+    @Option(names={"--allApplicationRole"}) @OutputFilter
+    private Boolean allApplicationRole;
+
+    @Option(names={"--description"}, hidden = true) @AddAsDefaultColumn
+    private String description;
+
+    @Override
     protected GetRequest generateRequest(UnirestInstance unirest) {
         return unirest.get(SSCUrls.ROLES).queryString("limit", "-1");
     }
+
 }

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleListCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/cmd/SSCRoleListCommand.java
@@ -45,10 +45,10 @@ public class SSCRoleListCommand extends AbstractSSCTableOutputCommand {
     @Option(names={"--name"}) @SSCFilterQParam @AddAsDefaultColumn
     private String name;
 
-    @Option(names={"--builtIn"}) @OutputFilter
+    @Option(names={"--built-in"}) @OutputFilter
     private Boolean builtIn;
 
-    @Option(names={"--allApplicationRole"}) @OutputFilter
+    @Option(names={"--universal-access"}) @OutputFilter
     private Boolean allApplicationRole;
 
     @Option(names={"--description"}, hidden = true) @AddAsDefaultColumn

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/mixin/SSCRoleResolverMixin.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/mixin/SSCRoleResolverMixin.java
@@ -40,12 +40,12 @@ public class SSCRoleResolverMixin {
         public abstract String getRoleNameOrId();
 
         @SneakyThrows
-        public SSCRoleDescriptor getRole(UnirestInstance unirestInstance){
-            return SSCRoleHelper.getRole(unirestInstance, getRoleNameOrId());
+        public SSCRoleDescriptor getRole(UnirestInstance unirestInstance, String... fields){
+            return SSCRoleHelper.getRole(unirestInstance, getRoleNameOrId(), fields);
         }
         
         public String getRoleId(UnirestInstance unirestInstance) {
-            return getRole(unirestInstance).getRoleId();
+            return getRole(unirestInstance, "id").getRoleId();
         }
     }
 

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/mixin/SSCRoleResolverMixin.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/mixin/SSCRoleResolverMixin.java
@@ -24,17 +24,14 @@
  ******************************************************************************/
 package com.fortify.cli.ssc.role.cli.mixin;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fortify.cli.common.rest.runner.UnexpectedHttpResponseException;
-import com.fortify.cli.ssc.rest.SSCUrls;
+import com.fortify.cli.ssc.role.helper.SSCRoleDescriptor;
+import com.fortify.cli.ssc.role.helper.SSCRoleHelper;
 import io.micronaut.core.annotation.ReflectiveAccess;
-import kong.unirest.GetRequest;
 import kong.unirest.UnirestInstance;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
-import javax.validation.ValidationException;
 
 @ReflectiveAccess
 public class SSCRoleResolverMixin {
@@ -43,27 +40,12 @@ public class SSCRoleResolverMixin {
         public abstract String getRoleNameOrId();
 
         @SneakyThrows
-        public String getRole(UnirestInstance unirestInstance){
-            String roleNameOrId = getRoleNameOrId();
-
-            GetRequest request = unirestInstance.get(SSCUrls.ROLE(roleNameOrId))
-                    .queryString("fields", "id,name");
-
-            try{
-                return request.asObject(ObjectNode.class).getBody().get("data").get("id").asText();
-            }catch (UnexpectedHttpResponseException | NullPointerException e){
-                request = unirestInstance.get(SSCUrls.ROLES)
-                        .queryString("q", String.format("name:\"%s\"",roleNameOrId));
-                try{
-                    return request.asObject(ObjectNode.class).getBody().get("data").get(0).get("id").asText();
-                }catch (UnexpectedHttpResponseException | NullPointerException ee){
-                    throw new ValidationException("Unable to find the specified role.");
-                }
-            }
+        public SSCRoleDescriptor getRole(UnirestInstance unirestInstance){
+            return SSCRoleHelper.getRole(unirestInstance, getRoleNameOrId());
         }
         
         public String getRoleId(UnirestInstance unirestInstance) {
-            return getRole(unirestInstance);
+            return getRole(unirestInstance).getRoleId();
         }
     }
 

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/mixin/SSCRoleResolverMixin.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/cli/mixin/SSCRoleResolverMixin.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * (c) Copyright 2020 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the 
+ * "Software"), to deal in the Software without restriction, including without 
+ * limitation the rights to use, copy, modify, merge, publish, distribute, 
+ * sublicense, and/or sell copies of the Software, and to permit persons to 
+ * whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included 
+ * in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY 
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.fortify.cli.ssc.role.cli.mixin;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.rest.runner.UnexpectedHttpResponseException;
+import com.fortify.cli.ssc.rest.SSCUrls;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import kong.unirest.GetRequest;
+import kong.unirest.UnirestInstance;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+import javax.validation.ValidationException;
+
+@ReflectiveAccess
+public class SSCRoleResolverMixin {
+    
+    public static abstract class AbstractSSCRoleMixin {
+        public abstract String getRoleNameOrId();
+
+        @SneakyThrows
+        public String getRole(UnirestInstance unirestInstance){
+            String roleNameOrId = getRoleNameOrId();
+
+            GetRequest request = unirestInstance.get(SSCUrls.ROLE(roleNameOrId))
+                    .queryString("fields", "id,name");
+
+            try{
+                return request.asObject(ObjectNode.class).getBody().get("data").get("id").asText();
+            }catch (UnexpectedHttpResponseException | NullPointerException e){
+                request = unirestInstance.get(SSCUrls.ROLES)
+                        .queryString("q", String.format("name:\"%s\"",roleNameOrId));
+                try{
+                    return request.asObject(ObjectNode.class).getBody().get("data").get(0).get("id").asText();
+                }catch (UnexpectedHttpResponseException | NullPointerException ee){
+                    throw new ValidationException("Unable to find the specified role.");
+                }
+            }
+        }
+        
+        public String getRoleId(UnirestInstance unirestInstance) {
+            return getRole(unirestInstance);
+        }
+    }
+
+    public static class Role extends AbstractSSCRoleMixin {
+        @Getter
+        @Option(names = {"--role"}, required = true, descriptionKey = "SSCRoleMixin")
+        private String roleNameOrId;
+    }
+
+    public static class PositionalParameter extends AbstractSSCRoleMixin {
+        @Getter
+        @Parameters(index = "0", arity = "1", descriptionKey = "SSCRoleMixin")
+        private String roleNameOrId;
+    }
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/helper/SSCRoleDescriptor.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/helper/SSCRoleDescriptor.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * (c) Copyright 2020 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.fortify.cli.ssc.role.helper;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fortify.cli.common.json.JsonNodeHolder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+
+@Data @EqualsAndHashCode(callSuper=true)
+public class SSCRoleDescriptor extends JsonNodeHolder {
+    @JsonProperty("id") private String roleId;
+    @JsonProperty("name") private String name;
+    @JsonProperty("description") private String description;
+    @JsonProperty("builtIn") private Boolean builtIn;
+    @JsonProperty("allApplicationRole") private Boolean allApplicationRole;
+    @JsonProperty("deletable") private Boolean deletable;
+    @JsonProperty("permissionIds") private String[] permissionIds;
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/helper/SSCRoleHelper.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role/helper/SSCRoleHelper.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * (c) Copyright 2020 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the 
+ * "Software"), to deal in the Software without restriction, including without 
+ * limitation the rights to use, copy, modify, merge, publish, distribute, 
+ * sublicense, and/or sell copies of the Software, and to permit persons to 
+ * whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included 
+ * in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY 
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.fortify.cli.ssc.role.helper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.json.JsonHelper;
+import com.fortify.cli.common.rest.runner.UnexpectedHttpResponseException;
+import com.fortify.cli.ssc.rest.SSCUrls;
+import kong.unirest.GetRequest;
+import kong.unirest.UnirestInstance;
+
+import javax.validation.ValidationException;
+
+public class SSCRoleHelper {
+    public static final SSCRoleDescriptor getRole(UnirestInstance unirestInstance, String roleNameOrId, String... fields) {
+        GetRequest request = unirestInstance.get(SSCUrls.ROLE(roleNameOrId));
+
+        try{
+            if ( fields!=null && fields.length>0 ) {
+                request.queryString("fields", String.join(",", fields));
+            }
+
+            JsonNode role = request.asObject(ObjectNode.class).getBody().get("data");
+            return JsonHelper.treeToValue(role, SSCRoleDescriptor.class);
+
+        }catch (UnexpectedHttpResponseException | NullPointerException e){
+            try{
+                request = unirestInstance.get(SSCUrls.ROLES)
+                        .queryString("q", String.format("name:\"%s\"",roleNameOrId))
+                        .queryString("limit", "2");
+
+                if ( fields!=null && fields.length>0 ) {
+                    request.queryString("fields", String.join(",", fields));
+                }
+
+                JsonNode roles = request.asObject(ObjectNode.class).getBody().get("data");
+                if ( roles.size()==0 ) {
+                    throw new ValidationException("No role found for the role name or id: " + roleNameOrId);
+                } else if ( roles.size()>1 ) {
+                    throw new ValidationException("Multiple roles found for the role name or id: " + roleNameOrId);
+                }
+                return JsonHelper.treeToValue(roles.get(0), SSCRoleDescriptor.class);
+
+            }catch (UnexpectedHttpResponseException | NullPointerException ee){
+                throw new ValidationException("Unable to find the specified role: " + roleNameOrId);
+            }
+        }
+    }
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/cli/cmd/SSCRolePermissionCommands.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/cli/cmd/SSCRolePermissionCommands.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * (c) Copyright 2021 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+
+package com.fortify.cli.ssc.role_permission.cli.cmd;
+
+import picocli.CommandLine.Command;
+
+@Command(
+        name = "role-permission",
+        aliases = {"role-perm"},
+        subcommands = {
+                SSCRolePermissionListCommand.class
+        }
+
+)
+public class SSCRolePermissionCommands {
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/cli/cmd/SSCRolePermissionGetCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/cli/cmd/SSCRolePermissionGetCommand.java
@@ -24,46 +24,26 @@
  ******************************************************************************/
 package com.fortify.cli.ssc.role_permission.cli.cmd;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fortify.cli.common.output.cli.mixin.OutputConfig;
-import com.fortify.cli.common.output.cli.mixin.filter.AddAsDefaultColumn;
-import com.fortify.cli.common.output.cli.mixin.filter.OutputFilter;
 import com.fortify.cli.ssc.rest.SSCUrls;
-import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCTableOutputCommand;
+import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCGetCommand;
+import com.fortify.cli.ssc.role_permission.cli.mixin.SSCRolePermissionResolverMixin;
 import com.fortify.cli.ssc.util.SSCOutputConfigHelper;
 import io.micronaut.core.annotation.ReflectiveAccess;
 import kong.unirest.GetRequest;
 import kong.unirest.UnirestInstance;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
+import picocli.CommandLine.Mixin;
 import static com.fortify.cli.ssc.role_permission.helper.SSCRolePermissionHelper.flattenArrayProperty;
 
 @ReflectiveAccess
-@Command(name = "list")
-public class SSCRolePermissionListCommand extends AbstractSSCTableOutputCommand {
-    @Option(names={"--id"}) @OutputFilter @AddAsDefaultColumn
-    private String id;
-
-    @Option(names={"--name"}) @OutputFilter @AddAsDefaultColumn
-    private String name;
+@Command(name = "get")
+public class SSCRolePermissionGetCommand extends AbstractSSCGetCommand {
+    @Mixin
+    private SSCRolePermissionResolverMixin.PositionalParameter rolePermissionResolver;
 
     protected GetRequest generateRequest(UnirestInstance unirest) {
-        return unirest.get(SSCUrls.PERMISSIONS).queryString("limit", "-1");
-    }
-
-    private JsonNode transformRecord(JsonNode recordJsonNode) {
-        ObjectNode record = (ObjectNode)recordJsonNode;
-        String newRecord = "";
-        for (JsonNode e : record.get("dependsOnPermission")) {
-            newRecord += e.get("id").asText() + ",";
-        }
-        if(newRecord.length() > 1){
-            newRecord = newRecord.substring(0,newRecord.length()-1);
-        }
-        record.remove("dependsOnPermission");
-        record.put("dependsOnPermission", newRecord);
-        return record;
+        return unirest.get(SSCUrls.PERMISSION(rolePermissionResolver.getRolePermissionId(unirest)));
     }
 
     @Override

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/cli/cmd/SSCRolePermissionListCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/cli/cmd/SSCRolePermissionListCommand.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * (c) Copyright 2021 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a 
+ * copy of this software and associated documentation files (the 
+ * "Software"), to deal in the Software without restriction, including without 
+ * limitation the rights to use, copy, modify, merge, publish, distribute, 
+ * sublicense, and/or sell copies of the Software, and to permit persons to 
+ * whom the Software is furnished to do so, subject to the following 
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY 
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.fortify.cli.ssc.role_permission.cli.cmd;
+
+import com.fortify.cli.common.output.cli.mixin.filter.AddAsDefaultColumn;
+import com.fortify.cli.common.output.cli.mixin.filter.OutputFilter;
+import com.fortify.cli.ssc.rest.SSCUrls;
+import com.fortify.cli.ssc.rest.cli.cmd.AbstractSSCTableOutputCommand;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import kong.unirest.GetRequest;
+import kong.unirest.UnirestInstance;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@ReflectiveAccess
+@Command(name = "list")
+public class SSCRolePermissionListCommand extends AbstractSSCTableOutputCommand {
+    @Option(names={"--id"}) @OutputFilter @AddAsDefaultColumn
+    private String id;
+
+    @Option(names={"--name"}) @OutputFilter @AddAsDefaultColumn
+    private String name;
+
+    protected GetRequest generateRequest(UnirestInstance unirest) {
+        return unirest.get(SSCUrls.PERMISSIONS).queryString("limit", "-1");
+    }
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/cli/mixin/SSCRolePermissionResolverMixin.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/cli/mixin/SSCRolePermissionResolverMixin.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * (c) Copyright 2021 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY 
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.fortify.cli.ssc.role_permission.cli.mixin;
+
+import com.fortify.cli.ssc.role_permission.helper.SSCRolePermissionDescriptor;
+import com.fortify.cli.ssc.role_permission.helper.SSCRolePermissionHelper;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import kong.unirest.UnirestInstance;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+@ReflectiveAccess
+public class SSCRolePermissionResolverMixin {
+    
+    public static abstract class AbstractSSCRolePermissionMixin {
+        public abstract String getRolePermissionNameOrId();
+
+        @SneakyThrows
+        public SSCRolePermissionDescriptor getRolePermission(UnirestInstance unirestInstance){
+            return SSCRolePermissionHelper.getRolePermission(unirestInstance, getRolePermissionNameOrId(), "id", "name");
+        }
+        
+        public String getRolePermissionId(UnirestInstance unirestInstance) {
+            return getRolePermission(unirestInstance).getPermissionId();
+        }
+    }
+
+    public static class Role extends AbstractSSCRolePermissionMixin {
+        @Getter
+        @Option(names = {"--permission"}, required = true, descriptionKey = "SSCRolePermissionMixin")
+        private String rolePermissionNameOrId;
+    }
+
+    public static class PositionalParameter extends AbstractSSCRolePermissionMixin {
+        @Getter
+        @Parameters(index = "0", arity = "1", descriptionKey = "SSCRolePermissionMixin")
+        private String rolePermissionNameOrId;
+    }
+}

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/helper/SSCRolePermissionDescriptor.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/helper/SSCRolePermissionDescriptor.java
@@ -22,19 +22,19 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  ******************************************************************************/
+package com.fortify.cli.ssc.role_permission.helper;
 
-package com.fortify.cli.ssc.role_permission.cli.cmd;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fortify.cli.common.json.JsonNodeHolder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
-import picocli.CommandLine.Command;
-
-@Command(
-        name = "role-permission",
-        aliases = {"role-perm"},
-        subcommands = {
-                SSCRolePermissionGetCommand.class,
-                SSCRolePermissionListCommand.class
-        }
-
-)
-public class SSCRolePermissionCommands {
+@EqualsAndHashCode(callSuper=true)
+@Data
+public class SSCRolePermissionDescriptor extends JsonNodeHolder {
+    @JsonProperty("id") private String permissionId;
+    @JsonProperty("name") private String name;
+    @JsonProperty("description") private String description;
+    @JsonProperty("assignByDefault") private Boolean assignByDefault;
+    @JsonProperty("dependsOnPermission") private SSCRolePermissionDescriptor[] dependsOnPermissionIds;
 }

--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/helper/SSCRolePermissionHelper.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/role_permission/helper/SSCRolePermissionHelper.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * (c) Copyright 2021 Micro Focus or one of its affiliates
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to
+ * whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY 
+ * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.fortify.cli.ssc.role_permission.helper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fortify.cli.common.json.JsonHelper;
+import com.fortify.cli.common.rest.runner.UnexpectedHttpResponseException;
+import com.fortify.cli.ssc.rest.SSCUrls;
+import com.fortify.cli.ssc.rest.bulk.SSCBulkRequestBuilder;
+import com.fortify.cli.ssc.rest.bulk.SSCBulkRequestBuilder.SSCBulkResponse;
+import kong.unirest.GetRequest;
+import kong.unirest.UnirestInstance;
+import javax.validation.ValidationException;
+
+public class SSCRolePermissionHelper {
+
+    // TODO: This is pretty generic. Need to find a better class to put this method in.
+    public static final JsonNode flattenArrayProperty(JsonNode recordJsonNode, String propertyName, String propertyNameToFlattenOn) {
+        ObjectNode record = (ObjectNode)recordJsonNode;
+        String newRecord = "";
+        for (JsonNode e : record.get(propertyName)) {
+            newRecord += e.get(propertyNameToFlattenOn).asText() + ",";
+        }
+        if(newRecord.length() > 1){
+            newRecord = newRecord.substring(0,newRecord.length()-1);
+        }
+        record.remove(propertyName);
+        record.put(propertyName, newRecord);
+        return record;
+    }
+
+    public static final SSCRolePermissionDescriptor getRolePermission(UnirestInstance unirestInstance, String rolePermissionNameOrId, String... fields) {
+        SSCBulkRequestBuilder bulkRequest = new SSCBulkRequestBuilder();
+        SSCBulkResponse response = null;
+        GetRequest rolePermissionRequest = unirestInstance.get(SSCUrls.PERMISSION(rolePermissionNameOrId));
+
+        // TODO: Need to find a better way to build the request URL. But using the #queryString method incorrectly
+        //  encodes spaces with the "+" character. This causes the bulk request to not return data for roles.
+        GetRequest rolePermissionsRequest = unirestInstance.get(
+                String.format("%s?q=name:%s&limit=2",
+                        SSCUrls.PERMISSIONS,
+                        rolePermissionNameOrId.replace(" ", "%20")
+                )
+        );
+
+        if ( fields!=null && fields.length>0 ) {
+            rolePermissionRequest.queryString("fields", String.join(",", fields));
+            rolePermissionsRequest.queryString("fields", String.join(",", fields));
+        }
+
+        bulkRequest.request("rolePermission", rolePermissionRequest);
+        bulkRequest.request("rolePermissions", rolePermissionsRequest);
+
+        try{
+            response = bulkRequest.execute(unirestInstance);
+        }catch (UnexpectedHttpResponseException | NullPointerException e){
+            throw new ValidationException("Unable to find the specified role: " + rolePermissionNameOrId);
+        }
+
+        JsonNode rolePermission = response.body("rolePermission").get("data");
+        if(rolePermission != null){
+            if(rolePermission.get("id") != null){
+                return JsonHelper.treeToValue(rolePermission, SSCRolePermissionDescriptor.class);
+            }
+        }
+
+        JsonNode rolePermissions = response.body("rolePermissions").get("data");
+        if (rolePermissions == null){
+            throw new ValidationException("No role permission found for the role permission name or id: " + rolePermissionNameOrId);
+        } else if( rolePermissions.size()==0 ) {
+            throw new ValidationException("No role permission found for the role permission name or id: " + rolePermissionNameOrId);
+        } else if ( rolePermissions.size()>1 ) {
+            throw new ValidationException("Multiple role permissions found for the role permission name or id: " + rolePermissionNameOrId);
+        }
+        return JsonHelper.treeToValue(rolePermissions.get(0), SSCRolePermissionDescriptor.class);
+    }
+}


### PR DESCRIPTION
Initial command implementation for `ssc roles`. `List`, `get`, `create`, and `delete`. Work is still being done on the `update` command.
This PR partially closes #47 .