### PR TITLE
Not wrap projectVersionId in quotes & added --limit and --order-by options

### DIFF
--- a/fcli-ssc/src/main/java/com/fortify/cli/ssc/event/cli/cmd/SSCEventListCommand.java
+++ b/fcli-ssc/src/main/java/com/fortify/cli/ssc/event/cli/cmd/SSCEventListCommand.java
@@ -44,7 +44,7 @@ public class SSCEventListCommand extends AbstractSSCListCommand {
                 .add("userName", SSCQParamValueGenerators::wrapInQuotes)
                 .add("eventType", SSCQParamValueGenerators::wrapInQuotes)
                 .add("detailedNote", SSCQParamValueGenerators::wrapInQuotes)
-                .add("applicationVersionId", "projectVersionId", SSCQParamValueGenerators::wrapInQuotes)
+                .add("applicationVersionId", "projectVersionId", SSCQParamValueGenerators::plain)
                 .add("required", SSCQParamValueGenerators::plain);
     }
     


### PR DESCRIPTION
For the `ssc event list` command.
The application version ID (project version ID) needs to **not** be surrounded with double quotes when used in the query string.

Also, the list command produces a lot of information. To help with this, I've added the `--limit` and `--order-by` options.