### PR TITLE
Fix config lang and missing asciidoctor dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,16 @@
+// the buildscript section is temporary until the missing dependency issue is resolved.
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath ("org.ysb33r.gradle:grolifant:0.16.2") {
+            force = true
+        }
+    }
+}
+
 plugins {
     id('com.github.jk1.dependency-license-report') version '2.1'
     id "org.kordamp.gradle.markdown" version "2.2.0"

--- a/fcli-config/src/main/java/com/fortify/cli/config/language/cli/cmd/LanguageGetCommand.java
+++ b/fcli-config/src/main/java/com/fortify/cli/config/language/cli/cmd/LanguageGetCommand.java
@@ -9,7 +9,6 @@ import picocli.CommandLine;
 )
 public class LanguageGetCommand extends AbstractLanguageCommand {
 
-    @PostConstruct
     @Override
     public void run() {
         System.out.println(languageConfigManager.getLanguageForHelp(languageConfigManager.getLanguage()));

--- a/fcli-config/src/main/java/com/fortify/cli/config/language/cli/cmd/LanguageListCommand.java
+++ b/fcli-config/src/main/java/com/fortify/cli/config/language/cli/cmd/LanguageListCommand.java
@@ -13,7 +13,6 @@ import picocli.CommandLine;
         name = "list"
 )
 public class LanguageListCommand extends AbstractLanguageCommand {
-    @PostConstruct
     @Override
     public void run() {
         System.out.println("Below is a list of supported languages with fcli:");

--- a/fcli-config/src/main/java/com/fortify/cli/config/language/cli/cmd/LanguageSetCommand.java
+++ b/fcli-config/src/main/java/com/fortify/cli/config/language/cli/cmd/LanguageSetCommand.java
@@ -12,7 +12,6 @@ public class LanguageSetCommand extends AbstractLanguageCommand {
     @Parameters(index = "0", descriptionKey = "fcli.config.language.set.language")
     private String language;
 
-    @PostConstruct
     @Override
     public void run() {
         languageConfigManager.setLanguage(language);


### PR DESCRIPTION
This PR addresses two things:
  - The bug with weird printing issues with the `config lang` commands. (#150)
  - And another very recent issue where a dependency of the asciidoctoe gradle plugin, suddently disappeared (#149 )